### PR TITLE
perf: improve PageSpeed scores — fonts, contrast, redirects

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,8 +1,5 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
-@import "@fontsource/ibm-plex-sans/400.css";
-@import "@fontsource/ibm-plex-sans/500.css";
-@import "@fontsource/ibm-plex-mono/400.css";
 
 @source "../../../content/**/*";
 
@@ -49,5 +46,21 @@ pre,
 	}
 	50% {
 		border-color: rgb(115 115 115);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	@keyframes typing-loop {
+		0%,
+		100% {
+			width: 16ch;
+		}
+	}
+
+	@keyframes blink-caret {
+		0%,
+		100% {
+			border-color: transparent;
+		}
 	}
 }

--- a/app/pages/articles/[slug].vue
+++ b/app/pages/articles/[slug].vue
@@ -66,7 +66,7 @@ useHead({
   <div class="min-h-screen text-[#e5e5e5]">
     <header class="py-6">
       <nav class="max-w-2xl mx-auto px-6">
-        <NuxtLink to="/" class="inline-flex items-center gap-1.5 text-sm text-neutral-500 hover:text-[#e5e5e5] transition-colors">
+        <NuxtLink to="/" class="inline-flex items-center gap-1.5 text-sm text-neutral-400 hover:text-[#e5e5e5] transition-colors">
           <UIcon name="i-lucide-arrow-left" class="size-3.5" />
           Back
         </NuxtLink>
@@ -79,11 +79,11 @@ useHead({
           <div class="flex items-center gap-3 mb-4">
             <time
               :datetime="articleDate.toISOString()"
-              class="text-xs text-neutral-500 font-mono"
+              class="text-xs text-neutral-400 font-mono"
             >
               {{ articleDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) }}
             </time>
-            <span v-if="article.category" class="text-xs text-neutral-600 font-mono">
+            <span v-if="article.category" class="text-xs text-neutral-400 font-mono">
               {{ article.category }}
             </span>
           </div>
@@ -92,7 +92,7 @@ useHead({
             <span
               v-for="tag in article.tags"
               :key="tag"
-              class="text-xs text-neutral-600 font-mono border border-neutral-800 px-2 py-0.5 rounded"
+              class="text-xs text-neutral-400 font-mono border border-neutral-700 px-2 py-0.5 rounded"
             >
               {{ tag }}
             </span>
@@ -106,7 +106,7 @@ useHead({
     </main>
 
     <footer class="py-8">
-      <div class="max-w-2xl mx-auto px-6 text-xs text-neutral-600">
+      <div class="max-w-2xl mx-auto px-6 text-xs text-neutral-400">
         © {{ currentYear }} Thao Nguyen Van
       </div>
     </footer>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,9 +29,9 @@ const { data: articles } = await useAsyncData("home:articles", async () => {
   <div class="min-h-screen text-[#e5e5e5]">
     <header class="py-8">
       <nav class="max-w-2xl mx-auto px-6 flex items-center justify-between">
-        <span class="inline-block overflow-hidden whitespace-nowrap border-r border-neutral-500 text-sm text-neutral-500 font-mono animate-[typing-loop_5s_infinite,blink-caret_0.75s_step-end_infinite]">thaolaptrinh.com</span>
+        <span class="inline-block overflow-hidden whitespace-nowrap border-r border-neutral-400 text-sm text-neutral-400 font-mono animate-[typing-loop_5s_infinite,blink-caret_0.75s_step-end_infinite]">thaolaptrinh.com</span>
         <a href="https://github.com/thaolaptrinh" target="_blank" rel="noopener"
-          class="text-sm text-neutral-500 hover:text-neutral-300 transition-colors">
+          class="text-sm text-neutral-400 hover:text-neutral-300 transition-colors">
           github
         </a>
       </nav>
@@ -60,27 +60,27 @@ const { data: articles } = await useAsyncData("home:articles", async () => {
                 <time
                   v-if="article.date"
                   :datetime="new Date(article.date).toISOString()"
-                  class="text-xs text-neutral-600 font-mono"
+                  class="text-xs text-neutral-400 font-mono"
                 >
                   {{
                     new Date(article.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
                   }}
                 </time>
-                <span v-if="article.category" class="text-xs text-neutral-500 font-mono">
+                <span v-if="article.category" class="text-xs text-neutral-400 font-mono">
                   {{ article.category }}
                 </span>
               </div>
               <h2 class="text-[#e5e5e5] text-lg leading-snug group-hover:text-neutral-400 transition-colors">
                 {{ article.title }}
               </h2>
-              <p v-if="article.description" class="text-neutral-500 text-sm mt-2 line-clamp-2">
+              <p v-if="article.description" class="text-neutral-400 text-sm mt-2 line-clamp-2">
                 {{ article.description }}
               </p>
             </NuxtLink>
           </article>
         </div>
 
-        <div v-if="!articles?.length" class="text-neutral-600 text-sm">
+        <div v-if="!articles?.length" class="text-neutral-400 text-sm">
           No articles yet.
         </div>
       </section>
@@ -88,7 +88,7 @@ const { data: articles } = await useAsyncData("home:articles", async () => {
 
     <footer class="py-12">
       <div class="max-w-2xl mx-auto px-6">
-        <p class="text-xs text-neutral-600">
+        <p class="text-xs text-neutral-400">
           © {{ currentYear }} Thao Nguyen Van
         </p>
       </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,7 @@ export default defineNuxtConfig({
 	compatibilityDate: "2025-07-15",
 	devtools: { enabled: true },
 	modules: [
+		"@nuxt/fonts",
 		"@nuxt/ui",
 		"@nuxt/content",
 		"nuxt-studio",
@@ -12,6 +13,13 @@ export default defineNuxtConfig({
 	],
 
 	css: ["~/assets/css/main.css"],
+
+	fonts: {
+		families: [
+			{ name: "IBM Plex Sans", provider: "google", weights: [400, 500] },
+			{ name: "IBM Plex Mono", provider: "google", weights: [400] },
+		],
+	},
 
 	content: {
 		build: {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.8",
+		"@nuxt/fonts": "^0.14.0",
 		"@nuxtjs/sitemap": "^7.6.0",
 		"typescript": "^5.9.3",
 		"vue-tsc": "^2.2.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.8
         version: 2.4.8
+      '@nuxt/fonts':
+        specifier: ^0.14.0
+        version: 0.14.0(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.2))
       '@nuxtjs/sitemap':
         specifier: ^7.6.0
         version: 7.6.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(zod@4.3.6)

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+	"redirects": [
+		{
+			"source": "/:path*",
+			"has": [{ "type": "host", "value": "www.thaolaptrinh.com" }],
+			"destination": "https://thaolaptrinh.com/:path*",
+			"permanent": true
+		}
+	]
+}


### PR DESCRIPTION
## What

Improve PageSpeed Insights scores across homepage and article pages based on audit of both pages.

## Changes

**Font loading**
- Replace `@fontsource` CSS imports with `@nuxt/fonts` module (Google provider)
- Fonts are now self-hosted at build time under `_fonts/`, no third-party CDN dependency
- Automatic `<link rel="preload">` injection and `font-display: swap` — improves LCP on mobile

**Color contrast**
- Fix WCAG AA violations on article page (Accessibility was 96/100)
- `text-neutral-500` / `text-neutral-600` → `text-neutral-400` on metadata, tags, footer across both pages
- Tag border `neutral-800` → `neutral-700` for better visibility

**Animation**
- Add `@media (prefers-reduced-motion: reduce)` for the typing animation on homepage
- Text stays fully visible, caret stops blinking — improves Speed Index in Lighthouse

**Redirects**
- Add `vercel.json` to redirect `www.thaolaptrinh.com` → `thaolaptrinh.com` at edge level
- Eliminates the multiple redirects penalty in PageSpeed

## Expected score improvements

| Category | Before | After |
|----------|--------|-------|
| Accessibility (article) | 96 | 100 |
| Performance — LCP mobile | 2.1s | improved |
| Performance — Speed Index | 4.3s | improved |