### PR TITLE
fix: switch Shiki theme to github-dark-high-contrast for WCAG AA compliance

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
 		build: {
 			markdown: {
 				highlight: {
-					theme: "github-dark",
+					theme: "github-dark-high-contrast",
 					langs: [
 						"php",
 						"js",


### PR DESCRIPTION
## Problem

Article page Accessibility score is 96/100 due to color contrast failure in code blocks.

Root cause: Shiki `github-dark` theme uses `#6A737D` for comment tokens. Against Nuxt UI's `bg-muted` background (`neutral-800` = `#262626`), this gives a contrast ratio of **3.12:1** — below the WCAG AA requirement of 4.5:1.

## Fix

Switch to `github-dark-high-contrast` — GitHub's own accessibility-optimized dark theme.

- Comments: `#8b949e` on `#262626` = **4.99:1** ✅
- All other token types also pass WCAG AA in this theme

## Impact

- Article page Accessibility: 96 → 100
- Visual appearance remains consistent with the existing dark aesthetic